### PR TITLE
Test cleanup for CPAN Testers

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ Net::Ping     = 2.33
 Test::Builder = 0.86
 Test::More    = 0
 Tie::Scalar   = 0
+Time::HiRes   = 2.41
 
 [Prereqs / TestRequires]
 Test::Timer = 0.05

--- a/t/08-ping_tcp.t
+++ b/t/08-ping_tcp.t
@@ -46,7 +46,7 @@ SKIP: {
 
     ping_ok( 'localhost', 'Test localhost on the web port' );
 
-    ping_not_ok( '172.29.249.249', 'Hopefully this is never a routeable host' );
+    ping_not_ok( '203.0.113.90', 'Documentation address; non-routable' );
 
     # Test a few remote servers
     # Hopefully they are up when the tests are run.

--- a/t/11-ping_syn.t
+++ b/t/11-ping_syn.t
@@ -40,8 +40,8 @@ SKIP: {
 
     # Try a few remote servers
     my %webs = (
-      # Hopefully this is never a routeable host
-      '172.29.249.249'       => 0,
+      # Documentation address, non-routable
+      '203.0.113.90'       => 0,
 
       # Hopefully all these web ports are open
       'facebook.com.'  => 1,

--- a/t/12-syn_host.t
+++ b/t/12-syn_host.t
@@ -8,7 +8,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 8 * 3 + 4;
+use Test::More;
 use Test::Ping;
 
 use English '-no_match_vars';
@@ -42,8 +42,8 @@ SKIP: {
 
     # Try a few remote servers
     my %webs = (
-        # Hopefully this is never a routeable host
-        '172.29.249.249'       => 0,
+        # Documentation address; non-routable
+        '203.0.113.90'       => 0,
 
         # Hopefully all these web ports are open
         'www.geocities.com.'   => 1,
@@ -52,7 +52,6 @@ SKIP: {
         'www.yahoo.com.'       => 1,
         'www.about.com.'       => 1,
         'www.microsoft.com.'   => 1,
-        '127.0.0.1'            => 1,
     );
 
     time_atmost(
@@ -111,3 +110,4 @@ SKIP: {
     );
 }
 
+done_testing();


### PR DESCRIPTION
- added prereq Time::HiRes v2.41, it must have been forgotten when Makefile.PL was removed
- changed RFC 1918 address 172.29.249.249 to doc address 203.0.113.90 in t/08, t/11 and t/12, as the 1918 address could legitimately be in use
- removed 127.0.01 from t/12, as it was failing on some Testers
